### PR TITLE
Add `alternateName` in Website

### DIFF
--- a/docs/ref-parsed/index.json
+++ b/docs/ref-parsed/index.json
@@ -8029,6 +8029,7 @@
         "inLanguage",
         "url",
         "name",
+        "alternateName",
         "description",
         "image"
       ],
@@ -8089,6 +8090,13 @@
           "description": "Website の名前です。\nhttps://schema.org/name",
           "examples": [
             "手織り草木染ホウキボシ"
+          ]
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Website の別名です。\nhttps://schema.org/alternateName",
+          "examples": [
+            "houkiboshi.co"
           ]
         },
         "description": {
@@ -8594,6 +8602,13 @@
           "description": "Website の名前です。\nhttps://schema.org/name",
           "examples": [
             "手織り草木染ホウキボシ"
+          ]
+        },
+        "alternateName": {
+          "type": "string",
+          "description": "Website の別名です。\nhttps://schema.org/alternateName",
+          "examples": [
+            "houkiboshi.co"
           ]
         },
         "description": {

--- a/docs/ref-parsed/website.json
+++ b/docs/ref-parsed/website.json
@@ -12,6 +12,7 @@
     "inLanguage",
     "url",
     "name",
+    "alternateName",
     "description",
     "image"
   ],
@@ -72,6 +73,13 @@
       "description": "Website の名前です。\nhttps://schema.org/name",
       "examples": [
         "手織り草木染ホウキボシ"
+      ]
+    },
+    "alternateName": {
+      "type": "string",
+      "description": "Website の別名です。\nhttps://schema.org/alternateName",
+      "examples": [
+        "houkiboshi.co"
       ]
     },
     "description": {
@@ -577,6 +585,13 @@
       "description": "Website の名前です。\nhttps://schema.org/name",
       "examples": [
         "手織り草木染ホウキボシ"
+      ]
+    },
+    "alternateName": {
+      "type": "string",
+      "description": "Website の別名です。\nhttps://schema.org/alternateName",
+      "examples": [
+        "houkiboshi.co"
       ]
     },
     "description": {

--- a/docs/website.json
+++ b/docs/website.json
@@ -12,6 +12,7 @@
     "inLanguage",
     "url",
     "name",
+    "alternateName",
     "description",
     "image"
   ],
@@ -37,6 +38,9 @@
     },
     "name": {
       "$ref": "#/definitions/name"
+    },
+    "alternateName": {
+      "$ref": "#/definitions/alternateName"
     },
     "description": {
       "$ref": "#/definitions/description"
@@ -112,6 +116,13 @@
       "description": "Website の名前です。\nhttps://schema.org/name",
       "examples": [
         "手織り草木染ホウキボシ"
+      ]
+    },
+    "alternateName": {
+      "type": "string",
+      "description": "Website の別名です。\nhttps://schema.org/alternateName",
+      "examples": [
+        "houkiboshi.co"
       ]
     },
     "description": {

--- a/examples/website.json
+++ b/examples/website.json
@@ -6,6 +6,7 @@
   "inLanguage": "ja",
   "url": "https://houkiboshi.co/",
   "name": "手織り草木染ホウキボシ",
+  "alternateName": "houkiboshi.co",
   "description": "手織り・型染め・草木染めを専門とする鳥取県の工房です。",
   "image": {
     "@type": "ImageObject",

--- a/src/website.yml
+++ b/src/website.yml
@@ -15,6 +15,7 @@ required:
   - inLanguage
   - url
   - name
+  - alternateName
   - description
   - image
 additionalProperties: false
@@ -34,6 +35,8 @@ properties:
     $ref: '#/definitions/url'
   name:
     $ref: '#/definitions/name'
+  alternateName:
+    $ref: '#/definitions/alternateName'
   description:
     $ref: '#/definitions/description'
   image:
@@ -95,6 +98,13 @@ definitions:
       https://schema.org/name
     examples:
       - 手織り草木染ホウキボシ
+  alternateName:
+    type: string
+    description: |-
+      Website の別名です。
+      https://schema.org/alternateName
+    examples:
+      - houkiboshi.co
   description:
     type: string
     description: |-


### PR DESCRIPTION
@Luzlum 
Website の定義に別名用のフィールドを追加します。

`alternateName` というフィールド名は https://schema.org/WebSite で名前に関して利用可能なフィールドから選んだものです。

このフィールドの用途はいまのところ
favicon 系を生成するときにモバイルデバイスのホームに保存するようなケースで
アプリケーション名が必要だったため、これを指定できるようにする目的のみです。

用途を考えるとあまり長くない文字列を指定するのが良さそうです。

例)
* ホウキボシ
* houkiboshi.co
