### PR TITLE
Rename @ to __at__

### DIFF
--- a/docs/_definitions.json
+++ b/docs/_definitions.json
@@ -12,9 +12,9 @@
         "https://houkiboshi-fabric.github.io/schema/ref-parsed/product.json"
       ]
     },
-    "@context": {
+    "__at__context": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
       "enum": [
         "http://schema.org/"
       ],
@@ -22,9 +22,9 @@
         "http://schema.org/"
       ]
     },
-    "@type": {
+    "__at__type": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type",
       "examples": [
         "ImageObject",
         "Organization",
@@ -42,7 +42,7 @@
         "https://schema.org/Product"
       ]
     },
-    "@id": {
+    "__at__id": {
       "type": "string",
       "description": "JSON-LD フォーマットで定義する場合に利用します。\n外部から JSON-LD の node を参照する際の id となる IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\nhttps://w3c.github.io/json-ld-syntax/#node-identifiers"
     },
@@ -50,18 +50,18 @@
       "type": "object",
       "description": "https://schema.org/ImageObject",
       "required": [
-        "@type",
+        "__at__type",
         "url",
         "width",
         "height"
       ],
       "additionalProperties": false,
       "properties": {
-        "@context": {
-          "$ref": "#/definitions/@context"
+        "__at__context": {
+          "$ref": "#/definitions/__at__context"
         },
-        "@type": {
-          "$ref": "#/definitions/@type",
+        "__at__type": {
+          "$ref": "#/definitions/__at__type",
           "enum": [
             "ImageObject"
           ],

--- a/docs/author.json
+++ b/docs/author.json
@@ -6,8 +6,8 @@
   "type": "object",
   "required": [
     "$schema",
-    "@context",
-    "@type",
+    "__at__context",
+    "__at__type",
     "name",
     "image",
     "address",
@@ -19,11 +19,11 @@
     "$schema": {
       "$ref": "#/definitions/$schema"
     },
-    "@context": {
-      "$ref": "#/definitions/@context"
+    "__at__context": {
+      "$ref": "#/definitions/__at__context"
     },
-    "@type": {
-      "$ref": "#/definitions/@type"
+    "__at__type": {
+      "$ref": "#/definitions/__at__type"
     },
     "name": {
       "$ref": "#/definitions/name"
@@ -53,11 +53,11 @@
         "https://houkiboshi-fabric.github.io/schema/ref-parsed/author.json"
       ]
     },
-    "@context": {
-      "$ref": "_definitions.json#/definitions/@context"
+    "__at__context": {
+      "$ref": "_definitions.json#/definitions/__at__context"
     },
-    "@type": {
-      "$ref": "_definitions.json#/definitions/@type",
+    "__at__type": {
+      "$ref": "_definitions.json#/definitions/__at__type",
       "enum": [
         "Organization",
         "Person"

--- a/docs/ref-parsed/_definitions.json
+++ b/docs/ref-parsed/_definitions.json
@@ -12,9 +12,9 @@
         "https://houkiboshi-fabric.github.io/schema/ref-parsed/product.json"
       ]
     },
-    "@context": {
+    "__at__context": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
       "enum": [
         "http://schema.org/"
       ],
@@ -22,9 +22,9 @@
         "http://schema.org/"
       ]
     },
-    "@type": {
+    "__at__type": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type",
       "examples": [
         "ImageObject",
         "Organization",
@@ -42,7 +42,7 @@
         "https://schema.org/Product"
       ]
     },
-    "@id": {
+    "__at__id": {
       "type": "string",
       "description": "JSON-LD フォーマットで定義する場合に利用します。\n外部から JSON-LD の node を参照する際の id となる IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\nhttps://w3c.github.io/json-ld-syntax/#node-identifiers"
     },
@@ -50,16 +50,16 @@
       "type": "object",
       "description": "https://schema.org/ImageObject",
       "required": [
-        "@type",
+        "__at__type",
         "url",
         "width",
         "height"
       ],
       "additionalProperties": false,
       "properties": {
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -67,7 +67,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "ImageObject"
           ],
@@ -75,7 +75,7 @@
             "ImageObject"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "url": {
           "type": "string",

--- a/docs/ref-parsed/author.json
+++ b/docs/ref-parsed/author.json
@@ -6,8 +6,8 @@
   "type": "object",
   "required": [
     "$schema",
-    "@context",
-    "@type",
+    "__at__context",
+    "__at__type",
     "name",
     "image",
     "address",
@@ -25,9 +25,9 @@
       "type": "string",
       "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
     },
-    "@context": {
+    "__at__context": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
       "enum": [
         "http://schema.org/"
       ],
@@ -35,7 +35,7 @@
         "http://schema.org/"
       ]
     },
-    "@type": {
+    "__at__type": {
       "enum": [
         "Organization",
         "Person"
@@ -45,7 +45,7 @@
         "Person"
       ],
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
     },
     "name": {
       "type": "string",
@@ -58,16 +58,16 @@
       "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
       "type": "object",
       "required": [
-        "@type",
+        "__at__type",
         "url",
         "width",
         "height"
       ],
       "additionalProperties": false,
       "properties": {
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -75,7 +75,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "ImageObject"
           ],
@@ -83,7 +83,7 @@
             "ImageObject"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "url": {
           "type": "string",
@@ -159,9 +159,9 @@
       "type": "string",
       "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
     },
-    "@context": {
+    "__at__context": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
       "enum": [
         "http://schema.org/"
       ],
@@ -169,7 +169,7 @@
         "http://schema.org/"
       ]
     },
-    "@type": {
+    "__at__type": {
       "enum": [
         "Organization",
         "Person"
@@ -179,7 +179,7 @@
         "Person"
       ],
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
     },
     "name": {
       "type": "string",
@@ -192,16 +192,16 @@
       "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
       "type": "object",
       "required": [
-        "@type",
+        "__at__type",
         "url",
         "width",
         "height"
       ],
       "additionalProperties": false,
       "properties": {
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -209,7 +209,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "ImageObject"
           ],
@@ -217,7 +217,7 @@
             "ImageObject"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "url": {
           "type": "string",

--- a/docs/ref-parsed/index.json
+++ b/docs/ref-parsed/index.json
@@ -15,9 +15,9 @@
             "https://houkiboshi-fabric.github.io/schema/ref-parsed/product.json"
           ]
         },
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -25,9 +25,9 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type",
           "examples": [
             "ImageObject",
             "Organization",
@@ -45,7 +45,7 @@
             "https://schema.org/Product"
           ]
         },
-        "@id": {
+        "__at__id": {
           "type": "string",
           "description": "JSON-LD フォーマットで定義する場合に利用します。\n外部から JSON-LD の node を参照する際の id となる IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\nhttps://w3c.github.io/json-ld-syntax/#node-identifiers"
         },
@@ -53,16 +53,16 @@
           "type": "object",
           "description": "https://schema.org/ImageObject",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -70,7 +70,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -78,7 +78,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -125,8 +125,8 @@
       "type": "object",
       "required": [
         "$schema",
-        "@context",
-        "@type",
+        "__at__context",
+        "__at__type",
         "name",
         "image",
         "address",
@@ -144,9 +144,9 @@
           "type": "string",
           "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
         },
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -154,7 +154,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -164,7 +164,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -177,16 +177,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -194,7 +194,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -202,7 +202,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -278,9 +278,9 @@
           "type": "string",
           "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
         },
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -288,7 +288,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -298,7 +298,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -311,16 +311,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -328,7 +328,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -336,7 +336,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -8023,9 +8023,9 @@
       "type": "object",
       "required": [
         "$schema",
-        "@context",
-        "@type",
-        "@id",
+        "__at__context",
+        "__at__type",
+        "__at__id",
         "inLanguage",
         "url",
         "name",
@@ -8044,9 +8044,9 @@
           "type": "string",
           "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
         },
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -8054,7 +8054,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "WebSite"
           ],
@@ -8062,9 +8062,9 @@
             "WebSite"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
-        "@id": {
+        "__at__id": {
           "examples": [
             "https://houkiboshi.co/"
           ],
@@ -8107,16 +8107,16 @@
           "description": "Website を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -8124,7 +8124,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -8132,7 +8132,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -8162,7 +8162,7 @@
           "description": "Website の author です。",
           "additionalProperties": false,
           "properties": {
-            "@type": {
+            "__at__type": {
               "enum": [
                 "Organization",
                 "Person"
@@ -8172,7 +8172,7 @@
                 "Person"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "name": {
               "type": "string",
@@ -8185,16 +8185,16 @@
               "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
               "type": "object",
               "required": [
-                "@type",
+                "__at__type",
                 "url",
                 "width",
                 "height"
               ],
               "additionalProperties": false,
               "properties": {
-                "@context": {
+                "__at__context": {
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
                   "enum": [
                     "http://schema.org/"
                   ],
@@ -8202,7 +8202,7 @@
                     "http://schema.org/"
                   ]
                 },
-                "@type": {
+                "__at__type": {
                   "enum": [
                     "ImageObject"
                   ],
@@ -8210,7 +8210,7 @@
                     "ImageObject"
                   ],
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
                 },
                 "url": {
                   "type": "string",
@@ -8282,7 +8282,7 @@
           "description": "Website の publisher です。\nhttps://schema.org/publisher",
           "additionalProperties": false,
           "properties": {
-            "@type": {
+            "__at__type": {
               "enum": [
                 "Organization",
                 "Person"
@@ -8292,7 +8292,7 @@
                 "Person"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "name": {
               "type": "string",
@@ -8305,16 +8305,16 @@
               "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
               "type": "object",
               "required": [
-                "@type",
+                "__at__type",
                 "url",
                 "width",
                 "height"
               ],
               "additionalProperties": false,
               "properties": {
-                "@context": {
+                "__at__context": {
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
                   "enum": [
                     "http://schema.org/"
                   ],
@@ -8322,7 +8322,7 @@
                     "http://schema.org/"
                   ]
                 },
-                "@type": {
+                "__at__type": {
                   "enum": [
                     "ImageObject"
                   ],
@@ -8330,7 +8330,7 @@
                     "ImageObject"
                   ],
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
                 },
                 "url": {
                   "type": "string",
@@ -8423,7 +8423,7 @@
           "description": "著作権の所有者です。\nhttps://schema.org/copyrightHolder",
           "additionalProperties": false,
           "properties": {
-            "@type": {
+            "__at__type": {
               "enum": [
                 "Organization",
                 "Person"
@@ -8433,7 +8433,7 @@
                 "Person"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "name": {
               "type": "string",
@@ -8446,16 +8446,16 @@
               "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
               "type": "object",
               "required": [
-                "@type",
+                "__at__type",
                 "url",
                 "width",
                 "height"
               ],
               "additionalProperties": false,
               "properties": {
-                "@context": {
+                "__at__context": {
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
                   "enum": [
                     "http://schema.org/"
                   ],
@@ -8463,7 +8463,7 @@
                     "http://schema.org/"
                   ]
                 },
-                "@type": {
+                "__at__type": {
                   "enum": [
                     "ImageObject"
                   ],
@@ -8471,7 +8471,7 @@
                     "ImageObject"
                   ],
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
                 },
                 "url": {
                   "type": "string",
@@ -8556,9 +8556,9 @@
           "type": "string",
           "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
         },
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -8566,7 +8566,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "WebSite"
           ],
@@ -8574,9 +8574,9 @@
             "WebSite"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
-        "@id": {
+        "__at__id": {
           "examples": [
             "https://houkiboshi.co/"
           ],
@@ -8619,16 +8619,16 @@
           "description": "Website を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -8636,7 +8636,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -8644,7 +8644,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -8674,7 +8674,7 @@
           "description": "Website の author です。",
           "additionalProperties": false,
           "properties": {
-            "@type": {
+            "__at__type": {
               "enum": [
                 "Organization",
                 "Person"
@@ -8684,7 +8684,7 @@
                 "Person"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "name": {
               "type": "string",
@@ -8697,16 +8697,16 @@
               "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
               "type": "object",
               "required": [
-                "@type",
+                "__at__type",
                 "url",
                 "width",
                 "height"
               ],
               "additionalProperties": false,
               "properties": {
-                "@context": {
+                "__at__context": {
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
                   "enum": [
                     "http://schema.org/"
                   ],
@@ -8714,7 +8714,7 @@
                     "http://schema.org/"
                   ]
                 },
-                "@type": {
+                "__at__type": {
                   "enum": [
                     "ImageObject"
                   ],
@@ -8722,7 +8722,7 @@
                     "ImageObject"
                   ],
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
                 },
                 "url": {
                   "type": "string",
@@ -8794,7 +8794,7 @@
           "description": "Website の publisher です。\nhttps://schema.org/publisher",
           "additionalProperties": false,
           "properties": {
-            "@type": {
+            "__at__type": {
               "enum": [
                 "Organization",
                 "Person"
@@ -8804,7 +8804,7 @@
                 "Person"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "name": {
               "type": "string",
@@ -8817,16 +8817,16 @@
               "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
               "type": "object",
               "required": [
-                "@type",
+                "__at__type",
                 "url",
                 "width",
                 "height"
               ],
               "additionalProperties": false,
               "properties": {
-                "@context": {
+                "__at__context": {
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
                   "enum": [
                     "http://schema.org/"
                   ],
@@ -8834,7 +8834,7 @@
                     "http://schema.org/"
                   ]
                 },
-                "@type": {
+                "__at__type": {
                   "enum": [
                     "ImageObject"
                   ],
@@ -8842,7 +8842,7 @@
                     "ImageObject"
                   ],
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
                 },
                 "url": {
                   "type": "string",
@@ -8935,7 +8935,7 @@
           "description": "著作権の所有者です。\nhttps://schema.org/copyrightHolder",
           "additionalProperties": false,
           "properties": {
-            "@type": {
+            "__at__type": {
               "enum": [
                 "Organization",
                 "Person"
@@ -8945,7 +8945,7 @@
                 "Person"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "name": {
               "type": "string",
@@ -8958,16 +8958,16 @@
               "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
               "type": "object",
               "required": [
-                "@type",
+                "__at__type",
                 "url",
                 "width",
                 "height"
               ],
               "additionalProperties": false,
               "properties": {
-                "@context": {
+                "__at__context": {
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
                   "enum": [
                     "http://schema.org/"
                   ],
@@ -8975,7 +8975,7 @@
                     "http://schema.org/"
                   ]
                 },
-                "@type": {
+                "__at__type": {
                   "enum": [
                     "ImageObject"
                   ],
@@ -8983,7 +8983,7 @@
                     "ImageObject"
                   ],
                   "type": "string",
-                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+                  "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
                 },
                 "url": {
                   "type": "string",

--- a/docs/ref-parsed/website.json
+++ b/docs/ref-parsed/website.json
@@ -6,9 +6,9 @@
   "type": "object",
   "required": [
     "$schema",
-    "@context",
-    "@type",
-    "@id",
+    "__at__context",
+    "__at__type",
+    "__at__id",
     "inLanguage",
     "url",
     "name",
@@ -27,9 +27,9 @@
       "type": "string",
       "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
     },
-    "@context": {
+    "__at__context": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
       "enum": [
         "http://schema.org/"
       ],
@@ -37,7 +37,7 @@
         "http://schema.org/"
       ]
     },
-    "@type": {
+    "__at__type": {
       "enum": [
         "WebSite"
       ],
@@ -45,9 +45,9 @@
         "WebSite"
       ],
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
     },
-    "@id": {
+    "__at__id": {
       "examples": [
         "https://houkiboshi.co/"
       ],
@@ -90,16 +90,16 @@
       "description": "Website を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
       "type": "object",
       "required": [
-        "@type",
+        "__at__type",
         "url",
         "width",
         "height"
       ],
       "additionalProperties": false,
       "properties": {
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -107,7 +107,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "ImageObject"
           ],
@@ -115,7 +115,7 @@
             "ImageObject"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "url": {
           "type": "string",
@@ -145,7 +145,7 @@
       "description": "Website の author です。",
       "additionalProperties": false,
       "properties": {
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -155,7 +155,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -168,16 +168,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -185,7 +185,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -193,7 +193,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -265,7 +265,7 @@
       "description": "Website の publisher です。\nhttps://schema.org/publisher",
       "additionalProperties": false,
       "properties": {
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -275,7 +275,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -288,16 +288,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -305,7 +305,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -313,7 +313,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -406,7 +406,7 @@
       "description": "著作権の所有者です。\nhttps://schema.org/copyrightHolder",
       "additionalProperties": false,
       "properties": {
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -416,7 +416,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -429,16 +429,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -446,7 +446,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -454,7 +454,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -539,9 +539,9 @@
       "type": "string",
       "description": "validation に利用する schema ファイルへのパスです。\nURI を指定すると remote ファイルを参照できます。\n相対パスで指定することで local ファイルを参照できます。"
     },
-    "@context": {
+    "__at__context": {
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
       "enum": [
         "http://schema.org/"
       ],
@@ -549,7 +549,7 @@
         "http://schema.org/"
       ]
     },
-    "@type": {
+    "__at__type": {
       "enum": [
         "WebSite"
       ],
@@ -557,9 +557,9 @@
         "WebSite"
       ],
       "type": "string",
-      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+      "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
     },
-    "@id": {
+    "__at__id": {
       "examples": [
         "https://houkiboshi.co/"
       ],
@@ -602,16 +602,16 @@
       "description": "Website を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
       "type": "object",
       "required": [
-        "@type",
+        "__at__type",
         "url",
         "width",
         "height"
       ],
       "additionalProperties": false,
       "properties": {
-        "@context": {
+        "__at__context": {
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
           "enum": [
             "http://schema.org/"
           ],
@@ -619,7 +619,7 @@
             "http://schema.org/"
           ]
         },
-        "@type": {
+        "__at__type": {
           "enum": [
             "ImageObject"
           ],
@@ -627,7 +627,7 @@
             "ImageObject"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "url": {
           "type": "string",
@@ -657,7 +657,7 @@
       "description": "Website の author です。",
       "additionalProperties": false,
       "properties": {
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -667,7 +667,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -680,16 +680,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -697,7 +697,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -705,7 +705,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -777,7 +777,7 @@
       "description": "Website の publisher です。\nhttps://schema.org/publisher",
       "additionalProperties": false,
       "properties": {
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -787,7 +787,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -800,16 +800,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -817,7 +817,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -825,7 +825,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",
@@ -918,7 +918,7 @@
       "description": "著作権の所有者です。\nhttps://schema.org/copyrightHolder",
       "additionalProperties": false,
       "properties": {
-        "@type": {
+        "__at__type": {
           "enum": [
             "Organization",
             "Person"
@@ -928,7 +928,7 @@
             "Person"
           ],
           "type": "string",
-          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+          "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
         },
         "name": {
           "type": "string",
@@ -941,16 +941,16 @@
           "description": "Author を象徴する画像ファイルデータです。\nhttps://schema.org/ImageObject",
           "type": "object",
           "required": [
-            "@type",
+            "__at__type",
             "url",
             "width",
             "height"
           ],
           "additionalProperties": false,
           "properties": {
-            "@context": {
+            "__at__context": {
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"@type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"@context\": \"http://schema.org/\" とある場合、\n\"@type\": \"Person\" は \"@type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n\"__at__type\" プロパティやその他のプロパティの IRI のコンテクストです。\n例えば \"__at__context\": \"http://schema.org/\" とある場合、\n\"__at__type\": \"Person\" は \"__at__type\": \"http://schema.org/Person\" と同じ意味になります。\nhttps://w3c.github.io/json-ld-syntax/#the-context",
               "enum": [
                 "http://schema.org/"
               ],
@@ -958,7 +958,7 @@
                 "http://schema.org/"
               ]
             },
-            "@type": {
+            "__at__type": {
               "enum": [
                 "ImageObject"
               ],
@@ -966,7 +966,7 @@
                 "ImageObject"
               ],
               "type": "string",
-              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"@context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
+              "description": "JSON-LD フォーマットで定義する場合に利用します。\n定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。\n\"__at__context\" プロパティを指定すると短縮して表記できます。\nhttps://w3c.github.io/json-ld-syntax/#specifying-the-type"
             },
             "url": {
               "type": "string",

--- a/docs/website.json
+++ b/docs/website.json
@@ -6,9 +6,9 @@
   "type": "object",
   "required": [
     "$schema",
-    "@context",
-    "@type",
-    "@id",
+    "__at__context",
+    "__at__type",
+    "__at__id",
     "inLanguage",
     "url",
     "name",
@@ -21,14 +21,14 @@
     "$schema": {
       "$ref": "#/definitions/$schema"
     },
-    "@context": {
-      "$ref": "#/definitions/@context"
+    "__at__context": {
+      "$ref": "#/definitions/__at__context"
     },
-    "@type": {
-      "$ref": "#/definitions/@type"
+    "__at__type": {
+      "$ref": "#/definitions/__at__type"
     },
-    "@id": {
-      "$ref": "#/definitions/@id"
+    "__at__id": {
+      "$ref": "#/definitions/__at__id"
     },
     "inLanguage": {
       "$ref": "#/definitions/inLanguage"
@@ -79,11 +79,11 @@
         "https://houkiboshi-fabric.github.io/schema/ref-parsed/website.json"
       ]
     },
-    "@context": {
-      "$ref": "_definitions.json#/definitions/@context"
+    "__at__context": {
+      "$ref": "_definitions.json#/definitions/__at__context"
     },
-    "@type": {
-      "$ref": "_definitions.json#/definitions/@type",
+    "__at__type": {
+      "$ref": "_definitions.json#/definitions/__at__type",
       "enum": [
         "WebSite"
       ],
@@ -91,8 +91,8 @@
         "WebSite"
       ]
     },
-    "@id": {
-      "$ref": "_definitions.json#/definitions/@id",
+    "__at__id": {
+      "$ref": "_definitions.json#/definitions/__at__id",
       "examples": [
         "https://houkiboshi.co/"
       ]
@@ -138,8 +138,8 @@
       "description": "Website の author です。",
       "additionalProperties": false,
       "properties": {
-        "@type": {
-          "$ref": "author.json#/definitions/@type"
+        "__at__type": {
+          "$ref": "author.json#/definitions/__at__type"
         },
         "name": {
           "$ref": "author.json#/definitions/name"
@@ -166,8 +166,8 @@
       "description": "Website の publisher です。\nhttps://schema.org/publisher",
       "additionalProperties": false,
       "properties": {
-        "@type": {
-          "$ref": "author.json#/definitions/@type"
+        "__at__type": {
+          "$ref": "author.json#/definitions/__at__type"
         },
         "name": {
           "$ref": "author.json#/definitions/name"
@@ -215,8 +215,8 @@
       "description": "著作権の所有者です。\nhttps://schema.org/copyrightHolder",
       "additionalProperties": false,
       "properties": {
-        "@type": {
-          "$ref": "author.json#/definitions/@type"
+        "__at__type": {
+          "$ref": "author.json#/definitions/__at__type"
         },
         "name": {
           "$ref": "author.json#/definitions/name"

--- a/examples/author.json
+++ b/examples/author.json
@@ -1,11 +1,11 @@
 {
   "$schema": "../docs/ref-parsed/author.json",
-  "@context": "http://schema.org/",
-  "@type": "Organization",
+  "__at__context": "http://schema.org/",
+  "__at__type": "Organization",
   "name": "手織り草木染ホウキボシ",
   "image": {
-    "@context": "http://schema.org/",
-    "@type": "ImageObject",
+    "__at__context": "http://schema.org/",
+    "__at__type": "ImageObject",
     "url": "../../assets/products/chojo/main.jpg",
     "width": 1000,
     "height": 1000

--- a/examples/website.json
+++ b/examples/website.json
@@ -1,15 +1,15 @@
 {
   "$schema": "../docs/ref-parsed/website.json",
-  "@context": "http://schema.org/",
-  "@type": "WebSite",
-  "@id": "https://houkiboshi.co/",
+  "__at__context": "http://schema.org/",
+  "__at__type": "WebSite",
+  "__at__id": "https://houkiboshi.co/",
   "inLanguage": "ja",
   "url": "https://houkiboshi.co/",
   "name": "手織り草木染ホウキボシ",
   "alternateName": "houkiboshi.co",
   "description": "手織り・型染め・草木染めを専門とする鳥取県の工房です。",
   "image": {
-    "@type": "ImageObject",
+    "__at__type": "ImageObject",
     "url": "../../assets/products/chojo/main.jpg",
     "width": 1252,
     "height": 630

--- a/src/_definitions.yml
+++ b/src/_definitions.yml
@@ -13,24 +13,24 @@ definitions:
     examples:
       - ../../schemas/product.json
       - https://houkiboshi-fabric.github.io/schema/ref-parsed/product.json
-  '@context':
+  __at__context:
     type: string
     description: |-
       JSON-LD フォーマットで定義する場合に利用します。
-      "@type" プロパティやその他のプロパティの IRI のコンテクストです。
-      例えば "@context": "http://schema.org/" とある場合、
-      "@type": "Person" は "@type": "http://schema.org/Person" と同じ意味になります。
+      "__at__type" プロパティやその他のプロパティの IRI のコンテクストです。
+      例えば "__at__context": "http://schema.org/" とある場合、
+      "__at__type": "Person" は "__at__type": "http://schema.org/Person" と同じ意味になります。
       https://w3c.github.io/json-ld-syntax/#the-context
     enum:
       - http://schema.org/
     examples:
       - http://schema.org/
-  '@type':
+  __at__type:
     type: string
     description: |-
       JSON-LD フォーマットで定義する場合に利用します。
       定義されているプロパティの型を参照する IRI (https://www.ietf.org/rfc/rfc3987.txt) です。
-      "@context" プロパティを指定すると短縮して表記できます。
+      "__at__context" プロパティを指定すると短縮して表記できます。
       https://w3c.github.io/json-ld-syntax/#specifying-the-type
     examples:
       - ImageObject
@@ -47,7 +47,7 @@ definitions:
       - https://schema.org/Blog
       - https://schema.org/BlogPosting
       - https://schema.org/Product
-  '@id':
+  __at__id:
     type: string
     description: |-
       JSON-LD フォーマットで定義する場合に利用します。
@@ -58,16 +58,16 @@ definitions:
     description: |-
       https://schema.org/ImageObject
     required:
-      - '@type'
+      - __at__type
       - url
       - width
       - height
     additionalProperties: false
     properties:
-      '@context':
-        $ref: '#/definitions/@context'
-      '@type':
-        $ref: '#/definitions/@type'
+      __at__context:
+        $ref: '#/definitions/__at__context'
+      __at__type:
+        $ref: '#/definitions/__at__type'
         enum:
           - ImageObject
         examples:

--- a/src/author.yml
+++ b/src/author.yml
@@ -9,8 +9,8 @@ description: |-
 type: object
 required:
   - $schema
-  - '@context'
-  - '@type'
+  - __at__context
+  - __at__type
   - name
   - image
   - address
@@ -21,10 +21,10 @@ additionalProperties: false
 properties:
   $schema:
     $ref: '#/definitions/$schema'
-  '@context':
-    $ref: '#/definitions/@context'
-  '@type':
-    $ref: '#/definitions/@type'
+  __at__context:
+    $ref: '#/definitions/__at__context'
+  __at__type:
+    $ref: '#/definitions/__at__type'
   name:
     $ref: '#/definitions/name'
   image:
@@ -45,10 +45,10 @@ definitions:
     examples:
       - ../../../schemas/author.json
       - https://houkiboshi-fabric.github.io/schema/ref-parsed/author.json
-  '@context':
-    $ref: '_definitions.json#/definitions/@context'
-  '@type':
-    $ref: '_definitions.json#/definitions/@type'
+  __at__context:
+    $ref: '_definitions.json#/definitions/__at__context'
+  __at__type:
+    $ref: '_definitions.json#/definitions/__at__type'
     enum:
       - Organization
       - Person

--- a/src/website.yml
+++ b/src/website.yml
@@ -9,9 +9,9 @@ description: |-
 type: object
 required:
   - $schema
-  - '@context'
-  - '@type'
-  - '@id'
+  - __at__context
+  - __at__type
+  - __at__id
   - inLanguage
   - url
   - name
@@ -23,12 +23,12 @@ additionalProperties: false
 properties:
   $schema:
     $ref: '#/definitions/$schema'
-  '@context':
-    $ref: '#/definitions/@context'
-  '@type':
-    $ref: '#/definitions/@type'
-  '@id':
-    $ref: '#/definitions/@id'
+  __at__context:
+    $ref: '#/definitions/__at__context'
+  __at__type:
+    $ref: '#/definitions/__at__type'
+  __at__id:
+    $ref: '#/definitions/__at__id'
   inLanguage:
     $ref: '#/definitions/inLanguage'
   url:
@@ -63,16 +63,16 @@ definitions:
     examples:
       - '../../../schemas/website.json'
       - 'https://houkiboshi-fabric.github.io/schema/ref-parsed/website.json'
-  '@context':
-    $ref: '_definitions.json#/definitions/@context'
-  '@type':
-    $ref: '_definitions.json#/definitions/@type'
+  __at__context:
+    $ref: '_definitions.json#/definitions/__at__context'
+  __at__type:
+    $ref: '_definitions.json#/definitions/__at__type'
     enum:
       - WebSite
     examples:
       - WebSite
-  '@id':
-    $ref: '_definitions.json#/definitions/@id'
+  __at__id:
+    $ref: '_definitions.json#/definitions/__at__id'
     examples:
       - 'https://houkiboshi.co/'
   inLanguage:
@@ -128,8 +128,8 @@ definitions:
       Website の author です。
     additionalProperties: false
     properties:
-      '@type':
-        $ref: 'author.json#/definitions/@type'
+      '__at__type':
+        $ref: 'author.json#/definitions/__at__type'
       name:
         $ref: 'author.json#/definitions/name'
       image:
@@ -149,8 +149,8 @@ definitions:
       https://schema.org/publisher
     additionalProperties: false
     properties:
-      '@type':
-        $ref: 'author.json#/definitions/@type'
+      __at__type:
+        $ref: 'author.json#/definitions/__at__type'
       name:
         $ref: 'author.json#/definitions/name'
       image:
@@ -197,8 +197,8 @@ definitions:
       https://schema.org/copyrightHolder
     additionalProperties: false
     properties:
-      '@type':
-        $ref: 'author.json#/definitions/@type'
+      __at__type:
+        $ref: 'author.json#/definitions/__at__type'
       name:
         $ref: 'author.json#/definitions/name'
       image:


### PR DESCRIPTION
* GraphQL in Gatsby cannot use at sign `@` as key name
  * GraphQL in Gatsby replaces at sign `@` to `_` automatically